### PR TITLE
Add a format flag to tag verification

### DIFF
--- a/builtin/tag.c
+++ b/builtin/tag.c
@@ -110,19 +110,13 @@ static int verify_tag(const char *name, const char *ref,
 	flags = GPG_VERIFY_VERBOSE;
 
 	if (fmt_pretty) {
-		//verify_ref_format(fmt_pretty);
-
-		// Create a `ref_array_item` in order to use `show_ref_array_item`
-		// XXX: Just copies code from `static new_ref_array_item` in ref_filter.c
+		verify_ref_format(fmt_pretty);
 		struct ref_array_item *ref_item;
-		FLEX_ALLOC_STR(ref_item, refname, name);
-		hashcpy(ref_item->objectname, sha1);
-		ref_item->kind = FILTER_REFS_TAGS;
-		ref_item->flag = 0;
 
-		show_ref_array_item(ref_item, fmt_pretty, 0);
-		free((char *)ref_item->symref);
-		free(ref_item);
+		ref_item = new_ref_item(name, sha1, 0);
+		ref_item->kind = FILTER_REFS_TAGS;
+		show_ref_item(ref_item, fmt_pretty, 0);
+		free_ref_item(ref_item);
 
 		flags = GPG_VERIFY_QUIET;
 	}

--- a/builtin/tag.c
+++ b/builtin/tag.c
@@ -106,7 +106,28 @@ static int delete_tag(const char *name, const char *ref,
 static int verify_tag(const char *name, const char *ref,
 				const unsigned char *sha1)
 {
-	return gpg_verify_tag(sha1, name, GPG_VERIFY_VERBOSE);
+	int flags;
+	flags = GPG_VERIFY_VERBOSE;
+
+	if (fmt_pretty) {
+		//verify_ref_format(fmt_pretty);
+
+		// Create a `ref_array_item` in order to use `show_ref_array_item`
+		// XXX: Just copies code from `static new_ref_array_item` in ref_filter.c
+		struct ref_array_item *ref_item;
+		FLEX_ALLOC_STR(ref_item, refname, name);
+		hashcpy(ref_item->objectname, sha1);
+		ref_item->kind = FILTER_REFS_TAGS;
+		ref_item->flag = 0;
+
+		show_ref_array_item(ref_item, fmt_pretty, 0);
+		free((char *)ref_item->symref);
+		free(ref_item);
+
+		flags = GPG_VERIFY_QUIET;
+	}
+
+	return gpg_verify_tag(sha1, name, flags);
 }
 
 static int do_sign(struct strbuf *buffer)

--- a/builtin/tag.c
+++ b/builtin/tag.c
@@ -30,8 +30,9 @@ static const char * const git_tag_usage[] = {
 
 static unsigned int colopts;
 static int force_sign_annotate;
+static const char *fmt_pretty;
 
-static int list_tags(struct ref_filter *filter, struct ref_sorting *sorting, const char *format)
+static int list_tags(struct ref_filter *filter, struct ref_sorting *sorting)
 {
 	struct ref_array array;
 	char *to_free = NULL;
@@ -42,23 +43,23 @@ static int list_tags(struct ref_filter *filter, struct ref_sorting *sorting, con
 	if (filter->lines == -1)
 		filter->lines = 0;
 
-	if (!format) {
+	if (!fmt_pretty) {
 		if (filter->lines) {
 			to_free = xstrfmt("%s %%(contents:lines=%d)",
 					  "%(align:15)%(refname:strip=2)%(end)",
 					  filter->lines);
-			format = to_free;
+			fmt_pretty= to_free;
 		} else
-			format = "%(refname:strip=2)";
+			fmt_pretty = "%(refname:strip=2)";
 	}
 
-	verify_ref_format(format);
+	verify_ref_format(fmt_pretty);
 	filter->with_commit_tag_algo = 1;
 	filter_refs(&array, filter, FILTER_REFS_TAGS);
 	ref_array_sort(sorting, &array);
 
 	for (i = 0; i < array.nr; i++)
-		show_ref_array_item(array.items[i], format, 0);
+		show_ref_array_item(array.items[i], fmt_pretty, 0);
 	ref_array_clear(&array);
 	free(to_free);
 
@@ -334,7 +335,6 @@ int cmd_tag(int argc, const char **argv, const char *prefix)
 	struct strbuf err = STRBUF_INIT;
 	struct ref_filter filter;
 	static struct ref_sorting *sorting = NULL, **sorting_tail = &sorting;
-	const char *format = NULL;
 	struct option options[] = {
 		OPT_CMDMODE('l', "list", &cmdmode, N_("list tag names"), 'l'),
 		{ OPTION_INTEGER, 'n', NULL, &filter.lines, N_("n"),
@@ -369,7 +369,7 @@ int cmd_tag(int argc, const char **argv, const char *prefix)
 			OPTION_CALLBACK, 0, "points-at", &filter.points_at, N_("object"),
 			N_("print only tags of the object"), 0, parse_opt_object_name
 		},
-		OPT_STRING(  0 , "format", &format, N_("format"), N_("format to use for the output")),
+		OPT_STRING(  0 , "format", &fmt_pretty, N_("format"), N_("format to use for the output")),
 		OPT_END()
 	};
 
@@ -410,7 +410,7 @@ int cmd_tag(int argc, const char **argv, const char *prefix)
 			run_column_filter(colopts, &copts);
 		}
 		filter.name_patterns = argv;
-		ret = list_tags(&filter, sorting, format);
+		ret = list_tags(&filter, sorting);
 		if (column_active(colopts))
 			stop_column_filter();
 		return ret;

--- a/builtin/tag.c
+++ b/builtin/tag.c
@@ -111,18 +111,12 @@ static int verify_tag(const char *name, const char *ref,
 
 	if (fmt_pretty) {
 		//verify_ref_format(fmt_pretty);
-
-		// Create a `ref_array_item` in order to use `show_ref_array_item`
-		// XXX: Just copies code from `static new_ref_array_item` in ref_filter.c
 		struct ref_array_item *ref_item;
-		FLEX_ALLOC_STR(ref_item, refname, name);
-		hashcpy(ref_item->objectname, sha1);
-		ref_item->kind = FILTER_REFS_TAGS;
-		ref_item->flag = 0;
 
-		show_ref_array_item(ref_item, fmt_pretty, 0);
-		free((char *)ref_item->symref);
-		free(ref_item);
+		ref_item = new_ref_item(name, sha1, 0);
+		ref_item->kind = FILTER_REFS_TAGS;
+		show_ref_item(ref_item, fmt_pretty, 0);
+		free_ref_item(ref_item);
 
 		flags = GPG_VERIFY_QUIET;
 	}

--- a/builtin/tag.c
+++ b/builtin/tag.c
@@ -108,20 +108,10 @@ static int verify_tag(const char *name, const char *ref,
 {
 	int flags;
 	flags = GPG_VERIFY_VERBOSE;
-
-	if (fmt_pretty) {
-		verify_ref_format(fmt_pretty);
-		struct ref_array_item *ref_item;
-
-		ref_item = new_ref_item(name, sha1, 0);
-		ref_item->kind = FILTER_REFS_TAGS;
-		show_ref_item(ref_item, fmt_pretty, 0);
-		free_ref_item(ref_item);
-
+	if (fmt_pretty)
 		flags = GPG_VERIFY_QUIET;
-	}
 
-	return gpg_verify_tag(sha1, name, flags);
+	return verify_and_format_tag(sha1, name, fmt_pretty, flags);
 }
 
 static int do_sign(struct strbuf *buffer)
@@ -440,8 +430,12 @@ int cmd_tag(int argc, const char **argv, const char *prefix)
 		die(_("--merged and --no-merged option are only allowed with -l"));
 	if (cmdmode == 'd')
 		return for_each_tag_name(argv, delete_tag);
-	if (cmdmode == 'v')
+	if (cmdmode == 'v') {
+		if (fmt_pretty)
+			verify_ref_format(fmt_pretty);
 		return for_each_tag_name(argv, verify_tag);
+
+	}
 
 	if (msg.given || msgfile) {
 		if (msg.given && msgfile)

--- a/builtin/verify-tag.c
+++ b/builtin/verify-tag.c
@@ -51,23 +51,18 @@ int cmd_verify_tag(int argc, const char **argv, const char *prefix)
 	if (verbose)
 		flags |= GPG_VERIFY_VERBOSE;
 
+	if (fmt_pretty) {
+		verify_ref_format(fmt_pretty);
+		flags |= GPG_VERIFY_QUIET;
+	}
+
 	while (i < argc) {
 		unsigned char sha1[20];
 		const char *name = argv[i++];
 		if (get_sha1(name, sha1))
 			had_error = !!error("tag '%s' not found.", name);
 		else {
-			if (fmt_pretty) {
-				verify_ref_format(fmt_pretty);
-				struct ref_array_item *ref_item;
-				ref_item = new_ref_item(name, sha1, 0);
-				ref_item->kind = FILTER_REFS_TAGS;
-				show_ref_item(ref_item, fmt_pretty, 0);
-				free_ref_item(ref_item);
-				flags |= GPG_VERIFY_QUIET;
-			}
-
-			if (gpg_verify_tag(sha1, name, flags))
+			if (verify_and_format_tag(sha1, name, fmt_pretty, flags))
 				had_error = 1;
 		}
 	}

--- a/gpg-interface.c
+++ b/gpg-interface.c
@@ -88,6 +88,9 @@ int check_signature(const char *payload, size_t plen, const char *signature,
 
 void print_signature_buffer(const struct signature_check *sigc, unsigned flags)
 {
+	if (flags & GPG_VERIFY_QUIET)
+		return;
+
 	const char *output = flags & GPG_VERIFY_RAW ?
 		sigc->gpg_status : sigc->gpg_output;
 

--- a/gpg-interface.h
+++ b/gpg-interface.h
@@ -3,6 +3,7 @@
 
 #define GPG_VERIFY_VERBOSE	1
 #define GPG_VERIFY_RAW		2
+#define GPG_VERIFY_QUIET	4
 
 struct signature_check {
 	char *payload;

--- a/ref-filter.c
+++ b/ref-filter.c
@@ -1329,6 +1329,14 @@ static struct ref_array_item *new_ref_array_item(const char *refname,
 	return ref;
 }
 
+/* Wrapper: Create ref_array_item w/o referencing container in function name */
+struct ref_array_item *new_ref_item(const char *refname,
+						 const unsigned char *objectname,
+						 int flag)
+{
+	return new_ref_array_item(refname, objectname, flag);
+}
+
 static int filter_ref_kind(struct ref_filter *filter, const char *refname)
 {
 	unsigned int i;
@@ -1424,6 +1432,12 @@ static void free_array_item(struct ref_array_item *item)
 {
 	free((char *)item->symref);
 	free(item);
+}
+
+/* Wrapper: Free ref_array_item w/o referencing container in function name */
+void free_ref_item(struct ref_array_item *ref_item)
+{
+	free_array_item(ref_item);
 }
 
 /* Free all memory allocated for ref_array */
@@ -1635,6 +1649,12 @@ void show_ref_array_item(struct ref_array_item *info, const char *format, int qu
 	fwrite(final_buf->buf, 1, final_buf->len, stdout);
 	pop_stack_element(&state.stack);
 	putchar('\n');
+}
+
+/* Wrapper: Show ref_array_item w/o referencing container in function name */
+void show_ref_item(struct ref_array_item *ref_item, const char *format, int quote_style)
+{
+	show_ref_array_item(ref_item, format, quote_style);
 }
 
 /*  If no sorting option is given, use refname to sort as default */

--- a/ref-filter.h
+++ b/ref-filter.h
@@ -107,4 +107,14 @@ struct ref_sorting *ref_default_sorting(void);
 /*  Function to parse --merged and --no-merged options */
 int parse_opt_merge_filter(const struct option *opt, const char *arg, int unset);
 
+/*
+ * Provide wrappers to expose the ref_array_item data structure independently
+ * of the container ref_array, e.g. to format-print individual refs.
+ */
+struct ref_array_item *new_ref_item(const char *refname,
+		const unsigned char *objectname, int flag);
+void show_ref_item(struct ref_array_item *ref_item, const char *format,
+		int quote_style);
+void free_ref_item(struct ref_array_item *ref_item);
+
 #endif /*  REF_FILTER_H  */

--- a/tag.c
+++ b/tag.c
@@ -3,6 +3,7 @@
 #include "commit.h"
 #include "tree.h"
 #include "blob.h"
+#include "ref-filter.h"
 
 const char *tag_type = "tag";
 
@@ -30,8 +31,8 @@ static int run_gpg_verify(const char *buf, unsigned long size, unsigned flags)
 	return ret;
 }
 
-int gpg_verify_tag(const unsigned char *sha1, const char *name_to_report,
-		unsigned flags)
+int verify_and_format_tag(const unsigned char *sha1, const char *name_to_report,
+		const char *fmt_pretty, unsigned flags)
 {
 	enum object_type type;
 	char *buf;
@@ -56,6 +57,15 @@ int gpg_verify_tag(const unsigned char *sha1, const char *name_to_report,
 	ret = run_gpg_verify(buf, size, flags);
 
 	free(buf);
+
+	if (fmt_pretty) {
+		struct ref_array_item *ref_item;
+		ref_item = new_ref_item(name_to_report, sha1, 0);
+		ref_item->kind = FILTER_REFS_TAGS;
+		show_ref_item(ref_item, fmt_pretty, 0);
+		free_ref_item(ref_item);
+	}
+
 	return ret;
 }
 

--- a/tag.h
+++ b/tag.h
@@ -17,7 +17,7 @@ extern int parse_tag_buffer(struct tag *item, const void *data, unsigned long si
 extern int parse_tag(struct tag *item);
 extern struct object *deref_tag(struct object *, const char *, int);
 extern struct object *deref_tag_noverify(struct object *);
-extern int gpg_verify_tag(const unsigned char *sha1,
-		const char *name_to_report, unsigned flags);
+extern int verify_and_format_tag(const unsigned char *sha1,
+		const char *name_to_report, const char *fmt_pretty, unsigned flags);
 
 #endif /* TAG_H */


### PR DESCRIPTION
Enables the reuse of `git tag -l`'s `--format` flag in `git tag -v`, which let's the caller cross-check the refname used for verification with the tagname in the verified tag object, e.g.:

``` bash
# As in .git/refs/tags
refname="v2.9.3"
# As in the tag object header
tagname=$(git tag -v "${refname}" --format="%(tag)")

# If the verification passed and the names match...
if [ $? -eq 0  -a "${refname}" == "${tagname}" ]
then 
    echo "This is a good tag!"
fi
```

This PR is very likely going to be rejected by the git folks. See discussion in comments below.
